### PR TITLE
Availability zone is just the last character

### DIFF
--- a/auth_network.tf
+++ b/auth_network.tf
@@ -26,7 +26,7 @@ resource "aws_subnet" "auth" {
   for_each          = var.az_list
 
   vpc_id            = local.vpc_id
-  cidr_block        = cidrsubnet(local.auth_cidr, 4, var.az_number[substr(each.key, 9, 1)])
+  cidr_block        = cidrsubnet(local.auth_cidr, 4, var.az_number[substr(each.key, -1, 1)])
   availability_zone = each.key
   tags = {
     Name            = "teleport-auth-${each.key}"

--- a/network.tf
+++ b/network.tf
@@ -24,7 +24,7 @@ resource "aws_subnet" "public" {
   for_each          = var.az_list
 
   vpc_id            = local.vpc_id
-  cidr_block        = cidrsubnet(local.bastion_cidr, 4, var.az_number[substr(each.key, 9, 1)])
+  cidr_block        = cidrsubnet(local.bastion_cidr, 4, var.az_number[substr(each.key, -1, 1)])
   availability_zone = each.key
 
   tags = {

--- a/node_network.tf
+++ b/node_network.tf
@@ -25,7 +25,7 @@ resource "aws_subnet" "node" {
   for_each          = var.az_list
 
   vpc_id            = local.vpc_id
-  cidr_block        = cidrsubnet(local.node_cidr, 4, var.az_number[substr(each.key, 9, 1)])
+  cidr_block        = cidrsubnet(local.node_cidr, 4, var.az_number[substr(each.key, -1, 1)])
   availability_zone = each.key
   tags = {
     Name            = "teleport-node-${each.key}"


### PR DESCRIPTION
The code in master works for all US availability zones, because their length is exactly 10 characters. For example, `us-east-1c` or `us-west-1d`. But it doesn't work for European availability zones like `eu-central-1b`, because the length is 13 characters

Proposed fix should solve this, taking always the last character, not 10th.