### PR TITLE
Fix all `tfsec` and `tflint` warnings

### DIFF
--- a/.github/workflows/terraform-lint.yaml
+++ b/.github/workflows/terraform-lint.yaml
@@ -1,0 +1,25 @@
+name: Lint (Terraform)
+
+on:
+  push:
+    branches:
+      - master
+    paths:
+      - '**.tf'
+      - '**.tf.json'
+      - '**.hcl'
+  pull_request:
+    paths:
+      - '**.tf'
+      - '**.tf.json'
+      - '**.hcl'
+  workflow_dispatch:
+
+jobs:
+  terraform-lint:
+    uses: gravitational/shared-workflows/.github/workflows/terraform-lint.yaml@main
+    permissions:
+      actions: read
+      contents: read
+      pull-requests: write
+      security-events: write

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.terraform

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # `teleport-cluster-terraform`
 
-This repo contains a reference Terraform module which configures a production worthy high-availability auto-scaling Teleport Cluster.
+This repo contains a reference Terraform module that configures a production-worthy high-availability auto-scaling Teleport Cluster.
 
 This cluster makes use of several AWS technologies, provisioned and configured using Terraform.
 
@@ -16,7 +16,7 @@ data "local_file" "license" {
     filename = "/Users/gus/Downloads/teleport/license.pem"
 }
 
-# alternatvely, load the license from a variable and write the file locally
+# alternatively, load the license from a variable and write the file locally
 # resource "local_file" "license" {
 #   sensitive_content = var.teleport_license
 #   filename          = "/tmp/license.pem"
@@ -86,11 +86,11 @@ module "teleport-cluster-terraform" {
   # PostgreSQL listener for database access (with --insecure due to the lack of TLS cert)
   route53_domain_acm_nlb_alias = "production-teleport-cluster-nlb.teleportdemo.net"
 
-  # Email for LetsEncrypt domain registration
+  # Email for Let's Encrypt domain registration
   email = "my@email.address"
 
-  # S3 bucket to create for encrypted LetsEncrypt certificates
-  # This is also used for storing the Teleport license which is downloaded to auth servers
+  # S3 bucket to create for encrypted Let's Encrypt certificates
+  # This is also used for storing the Teleport license that is downloaded to auth servers
   # This cannot be a pre-existing bucket
   s3_bucket_name = "production-teleport-cluster.teleportdemo.net"
 
@@ -133,16 +133,16 @@ Once this file is written, run `terraform init -upgrade && terraform plan && ter
 We recommend familiarizing yourself with the following resources prior to reviewing our Terraform examples:
 
 - [Teleport Architecture](https://goteleport.com/docs/architecture/overview/)
-- [Admin Guide](https://goteleport.com/docs/admin-guide/)
+- [Admin Guide](https://goteleport.com/docs/management/admin/)
 
 In order to spin up AWS resources using these Terraform examples, you need the following software:
 
-- terraform v0.13+ [install docs](https://learn.hashicorp.com/terraform/getting-started/install.html)
-- awscli v1.14+ [install docs](https://docs.aws.amazon.com/cli/latest/userguide/cli-chap-install.html)
+- terraform v1.0+ [install docs](https://learn.hashicorp.com/tutorials/terraform/install-cli)
+- awscli v1.14+ [install docs](https://docs.aws.amazon.com/cli/latest/userguide/getting-started-install.html)
 
 ## How to get help
 
-If you're having trouble, check out [Teleport discussions](ttps://github.com/gravitational/teleport/discussions).
+If you're having trouble, check out [Teleport discussions](https://github.com/gravitational/teleport/discussions).
 
 ## Public Teleport AMI IDs
 

--- a/assets/grafana-nginx.conf
+++ b/assets/grafana-nginx.conf
@@ -22,9 +22,9 @@ http {
 
 	##
 	# TLS settings - we are pretty strict here
-    # but well, it's a dev service, why not?
+	# but well, it's a dev service, why not?
 	##
-	ssl_protocols TLSv1.2;
+	ssl_protocols TLSv1.2 TLSv1.3;
 	ssl_prefer_server_ciphers on;
 
 	##
@@ -44,7 +44,7 @@ http {
     # Frontend grafana with TLS
     #
     server {
-        listen 8443 default_server ssl;
+        listen 8443 default_server ssl http2;
         ssl_certificate_key     /etc/tls/certs/privkey.pem;
         ssl_certificate  /etc/tls/certs/fullchain.pem;
         ssl_ciphers AES256+EECDH:AES256+EDH:!aNULL;

--- a/auth_asg.tf
+++ b/auth_asg.tf
@@ -3,7 +3,7 @@
 // as they are allowed to publish to SSM parameter store,
 // write certificates to encrypted S3 bucket.
 resource "aws_autoscaling_group" "auth" {
-  name                      = "${substr(var.cluster_name,0,16)}-auth"
+  name                      = "${substr(var.cluster_name, 0, 16)}-auth"
   max_size                  = 5
   min_size                  = length(var.az_list)
   health_check_grace_period = 300
@@ -44,10 +44,10 @@ resource "aws_launch_configuration" "auth" {
   lifecycle {
     create_before_destroy = true
   }
-  name_prefix                 = "${substr(var.cluster_name,0,16)}-auth-"
-  image_id                    = data.aws_ami.base.id
-  instance_type               = var.auth_instance_type
-  user_data                   = templatefile(
+  name_prefix   = "${substr(var.cluster_name, 0, 16)}-auth-"
+  image_id      = data.aws_ami.base.id
+  instance_type = var.auth_instance_type
+  user_data = templatefile(
     "${path.module}/auth-user-data.tpl",
     {
       region                   = data.aws_region.current.name
@@ -66,10 +66,15 @@ resource "aws_launch_configuration" "auth" {
       use_acm                  = var.use_acm
     }
   )
+  metadata_options {
+    http_tokens = "required"
+  }
+  root_block_device {
+    encrypted = true
+  }
   key_name                    = var.key_name
   ebs_optimized               = true
   associate_public_ip_address = false
   security_groups             = [aws_security_group.auth.id]
   iam_instance_profile        = aws_iam_instance_profile.auth.id
 }
-

--- a/bastion.tf
+++ b/bastion.tf
@@ -10,6 +10,15 @@ resource "aws_instance" "bastion" {
   source_dest_check           = false
   vpc_security_group_ids      = [aws_security_group.bastion.id]
   subnet_id                   = local.public_subnet_ids[0]
+
+  metadata_options {
+    http_tokens = "required"
+  }
+
+  root_block_device {
+    encrypted = true
+  }
+
   tags = {
     TeleportCluster = var.cluster_name
     TeleportRole    = "bastion"
@@ -23,15 +32,18 @@ resource "aws_instance" "bastion" {
 
 // Bastions are open to internet access
 resource "aws_security_group" "bastion" {
-  name   = "${var.cluster_name}-bastion"
-  vpc_id = local.vpc_id
+  name        = "${var.cluster_name}-bastion"
+  description = "Bastions are open to internet access"
+  vpc_id      = local.vpc_id
   tags = {
     TeleportCluster = var.cluster_name
   }
 }
 
 // Ingress traffic is allowed to SSH 22 port only
+// tfsec:ignore:aws-ec2-no-public-ingress-sgr
 resource "aws_security_group_rule" "bastion_ingress_allow_ssh" {
+  description       = "Ingress traffic is allowed to SSH only"
   type              = "ingress"
   from_port         = 22
   to_port           = 22
@@ -41,7 +53,9 @@ resource "aws_security_group_rule" "bastion_ingress_allow_ssh" {
 }
 
 // Egress traffic is allowed everywhere
+// tfsec:ignore:aws-ec2-no-public-egress-sgr
 resource "aws_security_group_rule" "proxy_egress_bastion_all_traffic" {
+  description       = "Egress traffic is allowed everywhere"
   type              = "egress"
   from_port         = 0
   to_port           = 0
@@ -49,4 +63,3 @@ resource "aws_security_group_rule" "proxy_egress_bastion_all_traffic" {
   cidr_blocks       = ["0.0.0.0/0"]
   security_group_id = aws_security_group.bastion.id
 }
-

--- a/defaults.tf
+++ b/defaults.tf
@@ -17,6 +17,7 @@ variable "grafana_version" {
 
 # Assign a number to each AZ letter used in our configuration
 variable "az_number" {
+  type    = map
   default = {
     a = 1
     b = 2
@@ -32,11 +33,12 @@ variable "az_number" {
 # Assign a number to each different subnet type that we use
 # This helps avoid conflicts across different availability zones
 variable "az_subnet_type" {
+  type    = map
   default = {
     bastion = 1
-    auth = 2
-    proxy = 3
-    node = 4
+    auth    = 2
+    proxy   = 3
+    node    = 4
     monitor = 5
   }
 }

--- a/dynamo.tf
+++ b/dynamo.tf
@@ -7,7 +7,14 @@ resource "aws_dynamodb_table" "teleport" {
   write_capacity = 20
   hash_key       = "HashKey"
   range_key      = "FullPath"
+
+  // For demo purposes, CMK isn't necessary
+  // tfsec:ignore:aws-dynamodb-table-customer-key
   server_side_encryption {
+    enabled = true
+  }
+
+  point_in_time_recovery {
     enabled = true
   }
 
@@ -49,7 +56,13 @@ resource "aws_dynamodb_table" "teleport_events" {
   hash_key       = "SessionID"
   range_key      = "EventIndex"
 
+  // For demo purposes, CMK isn't necessary
+  // tfsec:ignore:aws-dynamodb-table-customer-key
   server_side_encryption {
+    enabled = true
+  }
+
+  point_in_time_recovery {
     enabled = true
   }
 
@@ -138,6 +151,8 @@ EOF
 
 }
 
+// Not able to use a specific resource constraint
+// tfsec:ignore:aws-iam-no-policy-wildcards
 resource "aws_iam_role_policy" "autoscaler_cloudwatch" {
   name = "${var.cluster_name}-autoscaler-cloudwatch"
   role = aws_iam_role.autoscaler.id
@@ -210,4 +225,3 @@ resource "aws_appautoscaling_policy" "write_policy" {
     target_value = var.autoscale_write_target
   }
 }
-

--- a/locks.tf
+++ b/locks.tf
@@ -7,6 +7,16 @@ resource "aws_dynamodb_table" "locks" {
   write_capacity = 10
   hash_key       = "Lock"
 
+  // For demo purposes, CMK isn't necessary
+  // tfsec:ignore:aws-dynamodb-table-customer-key
+  server_side_encryption {
+    enabled = true
+  }
+
+  point_in_time_recovery {
+    enabled = true
+  }
+
   attribute {
     name = "Lock"
     type = "S"
@@ -21,4 +31,3 @@ resource "aws_dynamodb_table" "locks" {
     TeleportCluster = var.cluster_name
   }
 }
-

--- a/monitor_asg.tf
+++ b/monitor_asg.tf
@@ -2,7 +2,7 @@
 // Grafana is available on port 8443
 // Internal influxdb HTTP collector service listens on port 8086
 
-// letsencrypt
+// Let's Encrypt
 resource "aws_autoscaling_group" "monitor" {
   name                      = "${var.cluster_name}-monitor"
   max_size                  = 1
@@ -76,14 +76,16 @@ resource "aws_autoscaling_group" "monitor_acm" {
   }
 }
 
+// Needs to have a public IP
+// tfsec:ignore:aws-ec2-no-public-ip
 resource "aws_launch_configuration" "monitor" {
   lifecycle {
     create_before_destroy = true
   }
-  name_prefix                 = "${var.cluster_name}-monitor-"
-  image_id                    = var.ami_id
-  instance_type               = var.monitor_instance_type
-  user_data                   = templatefile(
+  name_prefix   = "${var.cluster_name}-monitor-"
+  image_id      = var.ami_id
+  instance_type = var.monitor_instance_type
+  user_data = templatefile(
     "${path.module}/monitor-user-data.tpl",
     {
       region           = data.aws_region.current.name
@@ -96,6 +98,12 @@ resource "aws_launch_configuration" "monitor" {
       use_acm          = var.use_acm
     }
   )
+  metadata_options {
+    http_tokens = "required"
+  }
+  root_block_device {
+    encrypted = true
+  }
   key_name                    = var.key_name
   ebs_optimized               = true
   associate_public_ip_address = true
@@ -103,10 +111,11 @@ resource "aws_launch_configuration" "monitor" {
   iam_instance_profile        = aws_iam_instance_profile.monitor.id
 }
 
-// Monitors support traffic comming from internal cluster subnets and expose 8443 for grafana
+// Monitors support traffic coming from internal cluster subnets and expose 8443 for grafana
 resource "aws_security_group" "monitor" {
-  name   = "${var.cluster_name}-monitor"
-  vpc_id = local.vpc_id
+  name        = "${var.cluster_name}-monitor"
+  description = "SG for ${var.cluster_name}-monitor"
+  vpc_id      = local.vpc_id
   tags = {
     TeleportCluster = var.cluster_name
   }
@@ -114,6 +123,7 @@ resource "aws_security_group" "monitor" {
 
 // SSH access via bastion only
 resource "aws_security_group_rule" "monitor_ingress_allow_ssh" {
+  description              = "SSH access via bastion only"
   type                     = "ingress"
   from_port                = 22
   to_port                  = 22
@@ -122,8 +132,10 @@ resource "aws_security_group_rule" "monitor_ingress_allow_ssh" {
   source_security_group_id = aws_security_group.bastion.id
 }
 
-// Ingress traffic to SSL port 8443 is allowed from everywhere (letsencrypt)
+// Ingress traffic to SSL port 8443 is allowed from everywhere (Let's Encrypt)
+// tfsec:ignore:aws-ec2-no-public-ingress-sgr
 resource "aws_security_group_rule" "monitor_ingress_allow_web" {
+  description       = "Ingress traffic to SSL port 8443 is allowed from everywhere (Lets Encrypt)"
   type              = "ingress"
   from_port         = 8443
   to_port           = 8443
@@ -134,7 +146,9 @@ resource "aws_security_group_rule" "monitor_ingress_allow_web" {
 }
 
 // Ingress traffic to non-SSL port 8444 is allowed from everywhere (ACM)
+// tfsec:ignore:aws-ec2-no-public-ingress-sgr
 resource "aws_security_group_rule" "monitor_ingress_allow_web_acm" {
+  description       = "Ingress traffic to non-SSL port 8444 is allowed from everywhere (ACM)"
   type              = "ingress"
   from_port         = 8444
   to_port           = 8444
@@ -147,6 +161,7 @@ resource "aws_security_group_rule" "monitor_ingress_allow_web_acm" {
 // Influxdb metrics collector traffic is limited to internal VPC CIDR
 // We use CIDR here because traffic arriving from NLB is not marked with security group
 resource "aws_security_group_rule" "monitor_collector_ingress_allow_vpc_cidr_traffic" {
+  description       = "Influxdb metrics collector traffic is limited to internal VPC CIDR"
   type              = "ingress"
   from_port         = 8086
   to_port           = 8086
@@ -156,7 +171,9 @@ resource "aws_security_group_rule" "monitor_collector_ingress_allow_vpc_cidr_tra
 }
 
 // All egress traffic is allowed
+// tfsec:ignore:aws-ec2-no-public-egress-sgr
 resource "aws_security_group_rule" "monitor_egress_allow_all_traffic" {
+  description       = "All egress traffic is allowed"
   type              = "egress"
   from_port         = 0
   to_port           = 0
@@ -200,4 +217,3 @@ resource "aws_lb_listener" "monitor" {
     type             = "forward"
   }
 }
-

--- a/network.tf
+++ b/network.tf
@@ -1,7 +1,7 @@
 // Public subnets and routing tables used for NAT gateways
 // and load balancers.
 resource "aws_route_table" "public" {
-  for_each  = var.az_list
+  for_each = var.az_list
 
   vpc_id = local.vpc_id
 
@@ -12,7 +12,7 @@ resource "aws_route_table" "public" {
 }
 
 resource "aws_route" "public_gateway" {
-  for_each               = aws_route_table.public
+  for_each = aws_route_table.public
 
   route_table_id         = each.value.id
   destination_cidr_block = "0.0.0.0/0"
@@ -21,7 +21,7 @@ resource "aws_route" "public_gateway" {
 }
 
 resource "aws_subnet" "public" {
-  for_each          = var.az_list
+  for_each = var.az_list
 
   vpc_id            = local.vpc_id
   cidr_block        = cidrsubnet(local.bastion_cidr, 4, var.az_number[substr(each.key, 9, 1)])
@@ -39,7 +39,7 @@ locals {
 }
 
 resource "aws_route_table_association" "public" {
-  for_each       = var.az_list
+  for_each = var.az_list
 
   subnet_id      = aws_subnet.public[each.key].id
   route_table_id = aws_route_table.public[each.key].id

--- a/node_asg.tf
+++ b/node_asg.tf
@@ -38,10 +38,10 @@ resource "aws_launch_configuration" "node" {
   lifecycle {
     create_before_destroy = true
   }
-  name_prefix                 = "${var.cluster_name}-node-"
-  image_id                    = var.ami_id
-  instance_type               = var.node_instance_type
-  user_data                   = templatefile(
+  name_prefix   = "${var.cluster_name}-node-"
+  image_id      = var.ami_id
+  instance_type = var.node_instance_type
+  user_data = templatefile(
     "${path.module}/node-user-data.tpl",
     {
       region           = data.aws_region.current.name
@@ -52,6 +52,12 @@ resource "aws_launch_configuration" "node" {
       use_acm          = var.use_acm
     }
   )
+  metadata_options {
+    http_tokens = "required"
+  }
+  root_block_device {
+    encrypted = true
+  }
   key_name                    = var.key_name
   associate_public_ip_address = false
   security_groups             = [aws_security_group.node.id]

--- a/provider.tf
+++ b/provider.tf
@@ -1,25 +1,17 @@
 terraform {
-  required_version = "> 0.13"
+  required_version = "> 1.0, < 2.0.0"
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 2.0"
-    }
-    template = {
-      source  = "hashicorp/template"
-      version = "~> 2.2.0"
+      version = "~> 4.0"
     }
     random = {
       source  = "hashicorp/random"
-      version = "~> 2.2.1"
+      version = "~> 3.0"
     }
     local = {
-      source = "hashicorp/local"
-      version = "~> 2.0.0"
+      source  = "hashicorp/local"
+      version = "~> 2.0"
     }
   }
-}
-
-variable "aws_max_retries" {
-  default = 5
 }

--- a/s3.tf
+++ b/s3.tf
@@ -1,38 +1,66 @@
-// S3 bucket is used to distribute letsencrypt certificates
+// S3 bucket is used to distribute Let's Encrypt certificates
+// For demo purposes, don't need bucket logging
+// tfsec:ignore:aws-s3-enable-bucket-logging
 resource "aws_s3_bucket" "certs" {
   bucket        = var.s3_bucket_name
-  acl           = "private"
   force_destroy = true
-  server_side_encryption_configuration {
-    rule {
-      apply_server_side_encryption_by_default {
-        sse_algorithm = "AES256"
-      }
+}
+
+resource "aws_s3_bucket_acl" "certs" {
+  bucket = aws_s3_bucket.certs.bucket
+  acl    = "private"
+}
+
+// For demo purposes, CMK is not needed
+// tfsec:ignore:aws-s3-encryption-customer-key
+resource "aws_s3_bucket_server_side_encryption_configuration" "certs" {
+  bucket = aws_s3_bucket.certs.bucket
+
+  rule {
+    apply_server_side_encryption_by_default {
+      sse_algorithm = "AES256"
     }
   }
 }
 
-resource "aws_s3_bucket_object" "grafana_teleport_dashboard" {
+resource "aws_s3_bucket_versioning" "certs" {
   bucket = aws_s3_bucket.certs.bucket
-  key    = "health-dashboard.json"
-  source = "${path.module}/assets/health-dashboard.json"
+
+  versioning_configuration {
+    status = "Enabled"
+  }
+}
+
+resource "aws_s3_bucket_public_access_block" "certs" {
+  bucket = aws_s3_bucket.certs.bucket
+
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+}
+
+resource "aws_s3_object" "grafana_teleport_dashboard" {
+  bucket     = aws_s3_bucket.certs.bucket
+  key        = "health-dashboard.json"
+  source     = "${path.module}/assets/health-dashboard.json"
   depends_on = [aws_s3_bucket.certs]
 }
 
 // Grafana nginx config (letsencrypt)
-resource "aws_s3_bucket_object" "grafana_teleport_nginx" {
-  bucket = aws_s3_bucket.certs.bucket
-  key    = "grafana-nginx.conf"
-  source = "${path.module}/assets/grafana-nginx.conf"
+resource "aws_s3_object" "grafana_teleport_nginx" {
+  bucket     = aws_s3_bucket.certs.bucket
+  key        = "grafana-nginx.conf"
+  source     = "${path.module}/assets/grafana-nginx.conf"
   depends_on = [aws_s3_bucket.certs]
-  count  = var.use_acm ? 0 : 1
+  count      = var.use_acm ? 0 : 1
 }
 
 // Grafana nginx config (ACM)
-resource "aws_s3_bucket_object" "grafana_teleport_nginx_acm" {
-  bucket = aws_s3_bucket.certs.bucket
-  key    = "grafana-nginx.conf"
-  source = "${path.module}/assets/grafana-nginx-acm.conf"
+resource "aws_s3_object" "grafana_teleport_nginx_acm" {
+  bucket     = aws_s3_bucket.certs.bucket
+  key        = "grafana-nginx.conf"
+  source     = "${path.module}/assets/grafana-nginx-acm.conf"
   depends_on = [aws_s3_bucket.certs]
-  count  = var.use_acm ? 1 : 0
+  count      = var.use_acm ? 1 : 0
 }

--- a/variables.tf
+++ b/variables.tf
@@ -24,7 +24,7 @@ variable "grafana_pass" {
 # Whether to use Amazon-issued certificates via ACM or not
 # This must be set to true for any use of ACM whatsoever, regardless of whether Terraform generates/approves the cert
 variable "use_acm" {
-  type = string
+  type = bool
 }
 
 # List of AZs to spawn auth/proxy instances in
@@ -41,7 +41,7 @@ variable "vpc_cidr" {
   default = "10.10.0.0/16"
 }
 
-# DNS and LetsEncrypt integration variables
+# DNS and Let's Encrypt integration variables
 
 # Zone name which will host DNS records, e.g. example.com
 # This must already be configured in Route 53
@@ -62,16 +62,16 @@ variable "route53_domain" {
 # it can be used by applications which connect to it directly (like kubectl) rather
 # than discovering the NLB's address through the Teleport API (like tsh does)
 variable "route53_domain_acm_nlb_alias" {
-  type = string
+  type    = string
   default = ""
 }
 
-# Email for LetsEncrypt domain registration
+# Email for Let's Encrypt domain registration
 variable "email" {
   type = string
 }
 
-# S3 bucket to create for encrypted LetsEncrypt certificates
+# S3 bucket to create for encrypted Let's Encrypt certificates
 # This is also used for storing the Teleport license which is downloaded to auth servers
 variable "s3_bucket_name" {
   type = string
@@ -109,6 +109,7 @@ variable "monitor_instance_type" {
 
 # AWS KMS alias used for encryption/decryption, defaults to alias used in SSM
 variable "kms_alias_name" {
+  type    = string
   default = "alias/aws/ssm"
 }
 

--- a/vpc.tf
+++ b/vpc.tf
@@ -12,7 +12,7 @@ resource "aws_vpc" "teleport" {
 resource "aws_eip" "nat" {
   for_each = var.az_list
 
-  vpc   = true
+  vpc = true
   tags = {
     TeleportCluster = var.cluster_name
   }
@@ -28,7 +28,7 @@ resource "aws_internet_gateway" "teleport" {
 
 // Creates nat gateway per availability zone
 resource "aws_nat_gateway" "teleport" {
-  for_each      = var.az_list
+  for_each = var.az_list
 
   allocation_id = aws_eip.nat[each.key].id
   subnet_id     = aws_subnet.public[each.key].id
@@ -49,10 +49,10 @@ locals {
 
   # Break up the VPC CIDR into chunks according to different instance type
   # This helps to avoid subnet CIDR conflicts if/when AZs change
-  auth_cidr = cidrsubnet(var.vpc_cidr, 4, var.az_subnet_type.auth)
+  auth_cidr    = cidrsubnet(var.vpc_cidr, 4, var.az_subnet_type.auth)
   bastion_cidr = cidrsubnet(var.vpc_cidr, 4, var.az_subnet_type.bastion)
-  node_cidr = cidrsubnet(var.vpc_cidr, 4, var.az_subnet_type.node)
-  monitor_cidr = cidrsubnet(var.vpc_cidr, 4, var.az_subnet_type.monitor)
-  proxy_cidr = cidrsubnet(var.vpc_cidr, 4, var.az_subnet_type.proxy)
+  node_cidr    = cidrsubnet(var.vpc_cidr, 4, var.az_subnet_type.node)
+  monitor_cidr = cidrsubnet(var.vpc_cidr, 4, var.az_subnet_type.monitor) # tflint-ignore: terraform_unused_declarations
+  proxy_cidr   = cidrsubnet(var.vpc_cidr, 4, var.az_subnet_type.proxy) # tflint-ignore: terraform_unused_declarations
 }
 


### PR DESCRIPTION
There were numerous `tfsec` and `tflint` warnings. Address all issues, adding ignores where needed to bring warning count down to zero.