### PR TITLE
Multiple fixes for "ghost" diffs

### DIFF
--- a/acm.tf
+++ b/acm.tf
@@ -18,13 +18,13 @@ resource "aws_acm_certificate" "cert" {
 }
 
 resource "aws_route53_record" "cert_validation" {
-  for_each = [
-  for dvo in aws_acm_certificate.cert.domain_validation_options : {
+  for_each = {
+  for dvo in aws_acm_certificate.cert[0].domain_validation_options : dvo.domain_name => {
     name   = dvo.resource_record_name
     record = dvo.resource_record_value
     type   = dvo.resource_record_type
   }
-  ]
+  }
   name            = each.value.name
   records         = [each.value.record]
   type            = each.value.type

--- a/acm.tf
+++ b/acm.tf
@@ -18,16 +18,26 @@ resource "aws_acm_certificate" "cert" {
 }
 
 resource "aws_route53_record" "cert_validation" {
-  name    = tolist(aws_acm_certificate.cert[0].domain_validation_options)[0].resource_record_name
-  type    = tolist(aws_acm_certificate.cert[0].domain_validation_options)[0].resource_record_type
-  zone_id = data.aws_route53_zone.proxy.zone_id
-  records = [tolist(aws_acm_certificate.cert[0].domain_validation_options)[0].resource_record_value]
-  ttl     = 60
-  count   = var.use_acm ? 1 : 0
+  for_each = {
+  for dvo in aws_acm_certificate.cert.domain_validation_options : dvo.domain_name => {
+    name   = dvo.resource_record_name
+    record = dvo.resource_record_value
+    type   = dvo.resource_record_type
+  }
+  }
+  name            = each.value.name
+  records         = [each.value.record]
+  type            = each.value.type
+  allow_overwrite = true
+  zone_id         = data.aws_route53_zone.proxy.zone_id
+
+  depends_on = [
+    aws_acm_certificate.cert
+  ]
 }
 
 resource "aws_acm_certificate_validation" "cert" {
   certificate_arn         = aws_acm_certificate.cert[0].arn
-  validation_record_fqdns = [aws_route53_record.cert_validation[0].fqdn]
+  validation_record_fqdns = [for record in aws_route53_record.cert_validation : record.fqdn]
   count                   = var.use_acm ? 1 : 0
 }

--- a/acm.tf
+++ b/acm.tf
@@ -19,11 +19,11 @@ resource "aws_acm_certificate" "cert" {
 
 resource "aws_route53_record" "cert_validation" {
   for_each = {
-  for dvo in aws_acm_certificate.cert[0].domain_validation_options : dvo.domain_name => {
-    name   = dvo.resource_record_name
-    record = dvo.resource_record_value
-    type   = dvo.resource_record_type
-  }
+    for dvo in aws_acm_certificate.cert[0].domain_validation_options : dvo.domain_name => {
+      name   = dvo.resource_record_name
+      record = dvo.resource_record_value
+      type   = dvo.resource_record_type
+    }
   }
   name            = each.value.name
   records         = [each.value.record]

--- a/acm.tf
+++ b/acm.tf
@@ -18,13 +18,13 @@ resource "aws_acm_certificate" "cert" {
 }
 
 resource "aws_route53_record" "cert_validation" {
-  for_each = {
-  for dvo in aws_acm_certificate.cert.domain_validation_options : dvo.domain_name => {
+  for_each = [
+  for dvo in aws_acm_certificate.cert.domain_validation_options : {
     name   = dvo.resource_record_name
     record = dvo.resource_record_value
     type   = dvo.resource_record_type
   }
-  }
+  ]
   name            = each.value.name
   records         = [each.value.record]
   type            = each.value.type

--- a/auth_asg.tf
+++ b/auth_asg.tf
@@ -47,7 +47,7 @@ resource "aws_launch_configuration" "auth" {
   name_prefix   = "${substr(var.cluster_name, 0, 16)}-auth-"
   image_id      = var.ami_id
   instance_type = var.auth_instance_type
-  user_data     = templatefile(
+  user_data = templatefile(
     "${path.module}/auth-user-data.tpl",
     {
       region                   = data.aws_region.current.name

--- a/auth_asg.tf
+++ b/auth_asg.tf
@@ -47,7 +47,7 @@ resource "aws_launch_configuration" "auth" {
   name_prefix   = "${substr(var.cluster_name, 0, 16)}-auth-"
   image_id      = var.ami_id
   instance_type = var.auth_instance_type
-  user_data = templatefile(
+  user_data     = templatefile(
     "${path.module}/auth-user-data.tpl",
     {
       region                   = data.aws_region.current.name
@@ -67,7 +67,8 @@ resource "aws_launch_configuration" "auth" {
     }
   )
   metadata_options {
-    http_tokens = "required"
+    http_endpoint = "enabled"
+    http_tokens   = "required"
   }
   root_block_device {
     encrypted = true

--- a/data.tf
+++ b/data.tf
@@ -8,8 +8,3 @@ data "aws_region" "current" {}
 data "aws_kms_alias" "ssm" {
   name = var.kms_alias_name
 }
-
-# Pick up the license path and make it accessible as a file
-data "local_file" "license" {
-  filename = var.license_path
-}

--- a/monitor_asg.tf
+++ b/monitor_asg.tf
@@ -85,7 +85,7 @@ resource "aws_launch_configuration" "monitor" {
   name_prefix   = "${var.cluster_name}-monitor-"
   image_id      = var.ami_id
   instance_type = var.monitor_instance_type
-  user_data     = templatefile(
+  user_data = templatefile(
     "${path.module}/monitor-user-data.tpl",
     {
       region           = data.aws_region.current.name
@@ -117,7 +117,7 @@ resource "aws_security_group" "monitor" {
   name        = "${var.cluster_name}-monitor"
   description = "SG for ${var.cluster_name}-monitor"
   vpc_id      = local.vpc_id
-  tags        = {
+  tags = {
     TeleportCluster = var.cluster_name
   }
 }

--- a/monitor_asg.tf
+++ b/monitor_asg.tf
@@ -85,7 +85,7 @@ resource "aws_launch_configuration" "monitor" {
   name_prefix   = "${var.cluster_name}-monitor-"
   image_id      = var.ami_id
   instance_type = var.monitor_instance_type
-  user_data = templatefile(
+  user_data     = templatefile(
     "${path.module}/monitor-user-data.tpl",
     {
       region           = data.aws_region.current.name
@@ -99,7 +99,8 @@ resource "aws_launch_configuration" "monitor" {
     }
   )
   metadata_options {
-    http_tokens = "required"
+    http_endpoint = "enabled"
+    http_tokens   = "required"
   }
   root_block_device {
     encrypted = true
@@ -116,7 +117,7 @@ resource "aws_security_group" "monitor" {
   name        = "${var.cluster_name}-monitor"
   description = "SG for ${var.cluster_name}-monitor"
   vpc_id      = local.vpc_id
-  tags = {
+  tags        = {
     TeleportCluster = var.cluster_name
   }
 }

--- a/node_asg.tf
+++ b/node_asg.tf
@@ -41,7 +41,7 @@ resource "aws_launch_configuration" "node" {
   name_prefix   = "${var.cluster_name}-node-"
   image_id      = var.ami_id
   instance_type = var.node_instance_type
-  user_data = templatefile(
+  user_data     = templatefile(
     "${path.module}/node-user-data.tpl",
     {
       region           = data.aws_region.current.name
@@ -53,7 +53,8 @@ resource "aws_launch_configuration" "node" {
     }
   )
   metadata_options {
-    http_tokens = "required"
+    http_endpoint = "enabled"
+    http_tokens   = "required"
   }
   root_block_device {
     encrypted = true

--- a/node_asg.tf
+++ b/node_asg.tf
@@ -41,7 +41,7 @@ resource "aws_launch_configuration" "node" {
   name_prefix   = "${var.cluster_name}-node-"
   image_id      = var.ami_id
   instance_type = var.node_instance_type
-  user_data     = templatefile(
+  user_data = templatefile(
     "${path.module}/node-user-data.tpl",
     {
       region           = data.aws_region.current.name

--- a/proxy_asg.tf
+++ b/proxy_asg.tf
@@ -100,7 +100,7 @@ resource "aws_launch_configuration" "proxy" {
   name_prefix   = "${substr(var.cluster_name, 0, 16)}-proxy-"
   image_id      = var.ami_id
   instance_type = var.proxy_instance_type
-  user_data = templatefile(
+  user_data     = templatefile(
     "${path.module}/proxy-user-data.tpl",
     {
       region                 = data.aws_region.current.name
@@ -117,7 +117,8 @@ resource "aws_launch_configuration" "proxy" {
     }
   )
   metadata_options {
-    http_tokens = "required"
+    http_endpoint = "enabled"
+    http_tokens   = "required"
   }
   root_block_device {
     encrypted = true

--- a/proxy_asg.tf
+++ b/proxy_asg.tf
@@ -100,7 +100,7 @@ resource "aws_launch_configuration" "proxy" {
   name_prefix   = "${substr(var.cluster_name, 0, 16)}-proxy-"
   image_id      = var.ami_id
   instance_type = var.proxy_instance_type
-  user_data     = templatefile(
+  user_data = templatefile(
     "${path.module}/proxy-user-data.tpl",
     {
       region                 = data.aws_region.current.name

--- a/ssm.tf
+++ b/ssm.tf
@@ -3,10 +3,10 @@
 // is destroyed, cluster will overwrite them with real values
 
 resource "aws_ssm_parameter" "license" {
-  count     = var.license_path != "" ? 1 : 0
+  count     = var.teleport_license != "" ? 1 : 0
   name      = "/teleport/${var.cluster_name}/license"
   type      = "SecureString"
-  value     = data.local_file.license.content
+  value     = var.teleport_license
   overwrite = true
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -83,6 +83,7 @@ variable "license_path" {
   default = ""
 }
 
+# Contents of the Teleport Enterprise license to be used for the cluster
 variable "teleport_license" {
   type      = string
   default   = ""

--- a/variables.tf
+++ b/variables.tf
@@ -83,6 +83,12 @@ variable "license_path" {
   default = ""
 }
 
+variable "teleport_license" {
+  type      = string
+  default   = ""
+  sensitive = true
+}
+
 # Instance type used for auth autoscaling group
 variable "auth_instance_type" {
   type    = string


### PR DESCRIPTION
While current apply claims to finish successfully, if launched subsequently, terraform will claim to detect drift and require another apply - in a never ending loop. See https://app.terraform.io/app/Gravitational/workspaces/aws-terraform-infra-dev/runs/run-HX6y5y8tLT4zSiSZ for example.

This fixes some (hopefully, all) of the issues causing this:

- fixes the issue with launch templates metadata, https://github.com/hashicorp/terraform-provider-aws/issues/25909#issuecomment-1218625304
- fixes the issue with the ordering of acm cert validation records in the state https://github.com/hashicorp/terraform-provider-aws/issues/8531#issuecomment-663562156
- gets rid of the license file, as it is created anew on each terraform run in terraform cloud, which then triggers the update on the SSM parameter with license

Plan: https://app.terraform.io/app/Gravitational/workspaces/aws-terraform-infra-dev/runs/run-qQK4ZLDeR46zuBAg